### PR TITLE
feat: Update chainId for devnet fuel asset

### DIFF
--- a/assets.gen.json
+++ b/assets.gen.json
@@ -39,7 +39,7 @@
         "chain": "devnet",
         "decimals": 9,
         "assetId": "0xf8f8b6283d7fa5b672b530cbb84fcccb4ff8dc40f8176ef4544ddb1f1952ad07",
-        "chainId": 0
+        "chainId": 1119889111
       },
       {
         "type": "fuel",

--- a/assets.json
+++ b/assets.json
@@ -32,6 +32,7 @@
             {
                 "type": "fuel",
                 "chain": "devnet",
+                "chainId": 1119889111,
                 "decimals": 9,
                 "assetId": "0xf8f8b6283d7fa5b672b530cbb84fcccb4ff8dc40f8176ef4544ddb1f1952ad07"
             },

--- a/assets.json
+++ b/assets.json
@@ -32,7 +32,6 @@
             {
                 "type": "fuel",
                 "chain": "devnet",
-                "chainId": 1119889111,
                 "decimals": 9,
                 "assetId": "0xf8f8b6283d7fa5b672b530cbb84fcccb4ff8dc40f8176ef4544ddb1f1952ad07"
             },

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
       "baseSepolia": 84532
     },
     "fuel": {
-      "devnet": 0,
+      "devnet": 1119889111,
       "testnet": 0,
       "mainnet": 9889
     }


### PR DESCRIPTION
Add the chainId 1119889111 to the devnet "fuel" asset entry in assets.json. This explicitly identifies the chain for that asset, helping avoid ambiguity and enabling correct chain-specific handling or signing for devnet transactions.

## Asset Name
<!-- wETH -->

## Link to issue ID
<!-- Provide a link to the submitted issue with asset information -->
<!-- For example: https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 -->
